### PR TITLE
	When matching id, find style elements in dom with given id

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,22 +2,31 @@
 
 var cache = {}
 
-module.exports = !global.document ? noop : function insertStyles (styles, options) {
+function noop () {}
+
+module.exports = !global.document ? noop : insertStyles
+
+function insertStyles (styles, options) {
   var id = options && options.id || styles
 
-  var element = cache[id] = (cache[id] || document.createElement('style'))
-  element.setAttribute('type', 'text/css')
+  var element = cache[id] = (cache[id] || createStyle(id))
 
   if ('textContent' in element) {
     element.textContent = styles
   } else {
     element.styleSheet.cssText = styles
   }
-
-  if (!element.parentNode) {
-    var head = document.getElementsByTagName('head')[0]
-    head.appendChild(element)
-  }
 }
 
-function noop () {}
+function createStyle (id) {
+  var element = document.getElementById(id)
+
+  if (element) return element
+
+  element = document.createElement('style')
+  element.setAttribute('type', 'text/css')
+
+  document.head.appendChild(element)
+
+  return element
+}

--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,23 @@ insertStyles('h1 { font-size: 14px }')
 //=> <head><style> h1 { ... }</style></head>
 ```
 
+## API
+
+#### `insertStyles(styles, [options]) -> void`
+
+##### styles
+
+Required. The string of styles to insert into the DOM.
+
+##### options
+
+###### id
+
+Calling `insertStyles` with the same `options.id` multiple times will re-use the same `<style>` element each time.
 
 ## Related
 
 * [insert-css](https://github.com/substack/insert-css)
-
 
 ## License
 

--- a/test/browser.js
+++ b/test/browser.js
@@ -41,6 +41,17 @@ test('browser', function (t) {
     cleanupStyles()
     t.end()
   })
+
+  t.test('picks up existing style tag', function (t) {
+    var style = document.createElement('style')
+    style.setAttribute('id', 'hello')
+    document.head.appendChild(style)
+
+    insertStyles('.hello {content: "world"}', {id: 'hello'})
+
+    t.equal(style.innerText, '.hello {content: "world"}')
+    t.end()
+  })
 })
 
 function cleanupStyles () {


### PR DESCRIPTION
- When id is given, look for an element with that id when getting an
  element from the in-memory cache (ideally that element is from the
  server)
- Act the same in Node and the browser
- Add options.prepend
